### PR TITLE
Setts the microsite base url

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,7 +52,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
       micrositeName := "SBT-Hood",
-      micrositeBaseUrl := "/hood/sbt",
+      micrositeBaseUrl := "/sbt-hood",
       micrositeDescription := "A SBT plugin for comparing benchmarks in your PRs",
       micrositeGithubOwner := "47degrees",
       micrositeGithubRepo := "sbt-hood",


### PR DESCRIPTION
Modifies the `micrositeBaseUrl` setting to "/sbt-hood", in order to fix the broken generated microsite