### PR TITLE
Downgrading sbt-org-policies version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.13.2")
+addSbtPlugin("com.47deg"          % "sbt-org-policies" % "0.13.1")
 addSbtPlugin("com.47deg"          % "sbt-microsites"   % "1.1.3")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"          % "0.3.7")


### PR DESCRIPTION
`sbt-microsites` is still using the `0.13.1` version of `sbt-org-policies` plugin and that makes the process to publish the microsite to fail. I'm downgrading the version until `sbt-microsites` is adapted to use the version `0.13.2` of `sbt-org-policies`