### PR TITLE
#147 - Edit GH comments instead of creating them

### DIFF
--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -261,7 +261,8 @@ object TaskAlgebra {
         )
 
         earliestHoodComment = commentsList.filter(_.body.contains(commentPrefix)).headOption
-        comment = s"## ${commentPrefix}:\n\n${benchmarkOutput(benchmarkResult, previousPath.getName, currentPath.getName)}"
+        comment =
+          s"## ${commentPrefix}:\n\n${benchmarkOutput(benchmarkResult, previousPath.getName, currentPath.getName)}"
 
         _ <- earliestHoodComment.fold(
           service.publishComment(
@@ -271,7 +272,7 @@ object TaskAlgebra {
             params.pullRequestNumber,
             comment
           )
-        )( ghComment =>
+        )(ghComment =>
           service.editComment(
             params.accessToken,
             params.repositoryOwner,

--- a/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
+++ b/modules/plugin/src/main/scala/com/fortysevendeg/hood/plugin/SbtHoodPlugin.scala
@@ -182,6 +182,8 @@ object SbtHoodPlugin extends AutoPlugin with SbtHoodDefaultSettings with SbtHood
 }
 
 object TaskAlgebra {
+  val commentPrefix = "sbt-hood benchmark result"
+
   def benchmarkTask[F[_]: Sync: Logger](
       previousPath: File,
       currentPath: File,
@@ -251,13 +253,34 @@ object TaskAlgebra {
   ): F[Either[Github4sError, Unit]] =
     GithubService.build[F](ExecutionContext.global).use { service =>
       (for {
-        _ <- service.publishComment(
+        commentsList <- service.listComments(
           params.accessToken,
           params.repositoryOwner,
           params.repositoryName,
-          params.pullRequestNumber,
-          s"## sbt-hood benchmark result:\n\n${benchmarkOutput(benchmarkResult, previousPath.getName, currentPath.getName)}"
+          params.pullRequestNumber
         )
+
+        earliestHoodComment = commentsList.filter(_.body.contains(commentPrefix)).headOption
+        comment = s"## ${commentPrefix}:\n\n${benchmarkOutput(benchmarkResult, previousPath.getName, currentPath.getName)}"
+
+        _ <- earliestHoodComment.fold(
+          service.publishComment(
+            params.accessToken,
+            params.repositoryOwner,
+            params.repositoryName,
+            params.pullRequestNumber,
+            comment
+          )
+        )( ghComment =>
+          service.editComment(
+            params.accessToken,
+            params.repositoryOwner,
+            params.repositoryName,
+            ghComment.id,
+            comment
+          )
+        )
+
         comparison = gitHubStateFromBenchmarks(benchmarkResult)
         _ <-
           if (shouldCreateStatus) {


### PR DESCRIPTION
Fixes: #147 

This PR adds code to detect if previous sbt-hood comments were added in an on-going PR, and in that case edits the earliest comment instead of adding new ones. For most cases (i.e.: any PR created after using this new version) that'll mean that only one sbt-hood comment will be added to the PR.