### PR TITLE
Update Scala to 2.12.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.11"
+ThisBuild / scalaVersion := "2.12.12"
 ThisBuild / organization := "com.47deg"
 
 addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; mdoc; testCovered")


### PR DESCRIPTION
The plugin needs to be compiled with 2.12.12 in order for both #217 and #214 to pass build, as sbt-mdoc is now requiring that as of recently.