### PR TITLE
Only allow updates for Scala 2.12

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+dependencyOverrides = [{
+  dependency = { groupId = "org.scala-lang", artifactId = "scala-library", version = { prefix = "2.12." } }
+}]


### PR DESCRIPTION
As a plugin, sbt-hood is, for now compatible only with Scala 2.12

This avoids to get other minor version updates